### PR TITLE
feat(mock): add MockERC20 contract for testing

### DIFF
--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -12,4 +12,8 @@ contract MockERC20 is ERC20 {
     constructor(string memory name, string memory symbol, uint256 initialSupply) ERC20(name, symbol) {
         _mint(msg.sender, initialSupply);
     }
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
 }

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -13,6 +13,11 @@ contract MockERC20 is ERC20 {
         _mint(msg.sender, initialSupply);
     }
 
+    /**
+     * @notice Mints tokens to any address (for testing)
+     * @param to Address to mint tokens to
+     * @param amount Amount of tokens to mint
+     */
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -1,4 +1,9 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+/**
+ * @title MockERC20
+ * @notice Simple ERC20 token for testing purposes
+ * @dev Allows anyone to mint tokens for testing
+ */
 contract MockERC20 {}

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -8,4 +8,8 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
  * @notice Simple ERC20 token for testing purposes
  * @dev Allows anyone to mint tokens for testing
  */
-contract MockERC20 is ERC20 {}
+contract MockERC20 is ERC20 {
+    constructor(string memory name, string memory symbol, uint256 initialSupply) ERC20(name, symbol) {
+        _mint(msg.sender, initialSupply);
+    }
+}

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -21,4 +21,8 @@ contract MockERC20 is ERC20 {
     function mint(address to, uint256 amount) external {
         _mint(to, amount);
     }
+
+    function mint(uint256 amount) external {
+        _mint(msg.sender, amount);
+    }
 }

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
 /**
  * @title MockERC20
  * @notice Simple ERC20 token for testing purposes

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -22,6 +22,10 @@ contract MockERC20 is ERC20 {
         _mint(to, amount);
     }
 
+    /**
+     * @notice Mints tokens to the caller (for testing)
+     * @param amount Amount of tokens to mint
+     */
     function mint(uint256 amount) external {
         _mint(msg.sender, amount);
     }

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -8,4 +8,4 @@ import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
  * @notice Simple ERC20 token for testing purposes
  * @dev Allows anyone to mint tokens for testing
  */
-contract MockERC20 {}
+contract MockERC20 is ERC20 {}

--- a/src/mock/MockERC20.sol
+++ b/src/mock/MockERC20.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockERC20 {}


### PR DESCRIPTION
# PR Description
## Summary
Introduces a `MockERC20` contract to support testing scenarios that require an ERC20-compatible token with flexible minting capabilities.

### What's Changed
- **New Contract**: `MockERC20` in `src/mock/MockERC20.sol`
- **Inheritance**: Extends OpenZeppelin’s `ERC20`
- **Constructor**: Initializes token with `name`, `symbol`, and `initialSupply`
- **Functions**:
  - `mint(address to, uint256 amount)` → mints tokens to a specified address
  - `mint(uint256 amount)` → mints tokens directly to the caller
- **NatSpec comments** added for contract and functions

### Why
- Provides a lightweight ERC20 token for unit and integration testing.
- Allows developers to simulate token transfers and balances without relying on external contracts.

### Impact
- Testing-only utility contract.
- No effect on production contracts or deployment logic.
